### PR TITLE
Remove solder paste from SMD test pads

### DIFF
--- a/Measurement_Point_Round-SMD-Pad_Big.kicad_mod
+++ b/Measurement_Point_Round-SMD-Pad_Big.kicad_mod
@@ -8,5 +8,5 @@
   (fp_text value Measurement_Point_Round-SMD-Pad_Big (at 2.54 3.81) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (pad 1 smd circle (at 0 0) (size 2.99974 2.99974) (layers F.Cu F.Paste F.Mask))
+  (pad 1 smd circle (at 0 0) (size 2.99974 2.99974) (layers F.Cu F.Mask))
 )

--- a/Measurement_Point_Round-SMD-Pad_Small.kicad_mod
+++ b/Measurement_Point_Round-SMD-Pad_Small.kicad_mod
@@ -8,5 +8,5 @@
   (fp_text value Measurement_Point_Round-SMD-Pad_Small (at 1.27 2.54) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (pad 1 smd circle (at 0 0) (size 1.524 1.524) (layers F.Cu F.Paste F.Mask))
+  (pad 1 smd circle (at 0 0) (size 1.524 1.524) (layers F.Cu F.Mask))
 )

--- a/Measurement_Point_Square-SMD-Pad_Big.kicad_mod
+++ b/Measurement_Point_Square-SMD-Pad_Big.kicad_mod
@@ -8,5 +8,5 @@
   (fp_text value Measurement_Point_Square-SMD-Pad_Big (at 2.54 3.81) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (pad 1 smd rect (at 0 0) (size 2.99974 2.99974) (layers F.Cu F.Paste F.Mask))
+  (pad 1 smd rect (at 0 0) (size 2.99974 2.99974) (layers F.Cu F.Mask))
 )

--- a/Measurement_Point_Square-SMD-Pad_Small.kicad_mod
+++ b/Measurement_Point_Square-SMD-Pad_Small.kicad_mod
@@ -8,5 +8,5 @@
   (fp_text value Measurement_Point_Square-SMD-Pad_Small (at 2.54 3.81) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (pad 1 smd rect (at 0 0) (size 1.50114 1.50114) (layers F.Cu F.Paste F.Mask))
+  (pad 1 smd rect (at 0 0) (size 1.50114 1.50114) (layers F.Cu F.Mask))
 )


### PR DESCRIPTION
I'd like to have the original plating when contacting them with pogo
pins. From my point of view it makes no sense for having reflowed solder on test pads by default.
